### PR TITLE
AI 리뷰 개선: 추가 커밋 시 최근 변경 중심 피드백

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,18 +22,18 @@ const reviewFunction = reviewFunctionsMap[AI_MODEL_PROVIDER] || null;
 
 async function runReview() {
   try {
-    // PR diff, 커밋 정보 가져오기
-    const [diff, commitDetails] = await Promise.all([
-      getPRDiff(),
-      getCommitDetails(),
-    ]);
-
     // 리뷰 함수 유효성 체크
     if (!reviewFunction) {
       throw new Error(
         `${AI_MODEL_PROVIDER}는 지원하지 않는 AI_MODEL_PROVIDER입니다.`
       );
     }
+
+    // PR diff, 커밋 정보 가져오기
+    const [diff, commitDetails] = await Promise.all([
+      getPRDiff(),
+      getCommitDetails(),
+    ]);
 
     // 코드 리뷰 생성
     const reviewComment = await reviewFunction({ diff, commitDetails });

--- a/utils/env.js
+++ b/utils/env.js
@@ -3,6 +3,9 @@
 export const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
 export const GITHUB_PR_NUMBER = process.env.GITHUB_PR_NUMBER;
 export const GITHUB_REPOSITORY = process.env.GITHUB_REPOSITORY;
+export const GITHUB_EVENT_ACTION = process.env.GITHUB_EVENT_ACTION;
+export const COMMIT_BEFORE = process.env.COMMIT_BEFORE;
+export const COMMIT_AFTER = process.env.COMMIT_AFTER;
 
 export const AI_API_KEY = process.env.AI_API_KEY;
 export const AI_MODEL = process.env.AI_MODEL;

--- a/utils/githubApi.js
+++ b/utils/githubApi.js
@@ -1,5 +1,12 @@
 // GitHub API 관련 함수 (diff 가져오기, 댓글 작성)
-import { GITHUB_TOKEN, GITHUB_PR_NUMBER, GITHUB_REPOSITORY } from "./env.js";
+import {
+  GITHUB_TOKEN,
+  GITHUB_PR_NUMBER,
+  GITHUB_REPOSITORY,
+  GITHUB_EVENT_ACTION,
+  COMMIT_BEFORE,
+  COMMIT_AFTER,
+} from "./env.js";
 
 async function fetchGitHubApi(url, options = {}) {
   const headers = {
@@ -18,12 +25,38 @@ async function fetchGitHubApi(url, options = {}) {
 
 // PR diff 가져오기
 export async function getPRDiff() {
-  const diffUrl = `https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${GITHUB_PR_NUMBER}`;
-  const response = await fetchGitHubApi(diffUrl, {
-    accept: "application/vnd.github.v3.diff",
-  });
+  if (GITHUB_EVENT_ACTION === "opened") {
+    // PR이 열렸을 때의 diff 가져오기
+    const diffUrl = `https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${GITHUB_PR_NUMBER}`;
+    const response = await fetchGitHubApi(diffUrl, {
+      accept: "application/vnd.github.v4.diff",
+    });
+    return response.text();
+  }
 
-  return response.text();
+  if (GITHUB_EVENT_ACTION === "synchronize" && COMMIT_BEFORE && COMMIT_AFTER) {
+    // 커밋이 추가되었을 때 이전과 이후 변경점 비교
+    const beforeCommitUrl = `https://api.github.com/repos/${GITHUB_REPOSITORY}/commits/${COMMIT_BEFORE}`;
+    const afterCommitUrl = `https://api.github.com/repos/${GITHUB_REPOSITORY}/commits/${COMMIT_AFTER}`;
+
+    const [beforeResponse, afterResponse] = await Promise.all([
+      fetchGitHubApi(beforeCommitUrl, {
+        accept: "application/vnd.github.v4.diff",
+      }),
+      fetchGitHubApi(afterCommitUrl, {
+        accept: "application/vnd.github.v4.diff",
+      }),
+    ]);
+
+    const [beforeDiff, afterDiff] = await Promise.all([
+      beforeResponse.text(),
+      afterResponse.text(),
+    ]);
+
+    return `Previous Commit Changes:\n\n${beforeDiff}\n\nLatest Commit Changes:\n\n${afterDiff}`;
+  }
+
+  throw new Error("Unsupported GitHub event action");
 }
 
 //  커밋 정보가져오기
@@ -40,7 +73,13 @@ export async function getCommitDetails() {
     body: commit.commit.message.split("\n").slice(1).join("\n").trim(), // 나머지 (내용)
   }));
 
-  return commitDetails;
+  if (GITHUB_EVENT_ACTION === "opened") {
+    return commitDetails; // 모든 커밋 반환
+  } else if (GITHUB_EVENT_ACTION === "synchronize") {
+    return [commitDetails[commitDetails.length - 1]]; // 최신 커밋만 반환
+  }
+
+  throw new Error("Unsupported GitHub event action");
 }
 
 // GitHub PR에 댓글 작성


### PR DESCRIPTION
- 기존 동작: PR 생성 및 추가 커밋 시 모든 변경 사항을 기반으로 AI 피드백을 요청.
- 문제점: 추가 커밋 시 전체 변경 사항을 검토해 비효율적이고 최근 변경에 집중 부족.

- 변경 사항: 추가 커밋 시 이전 변경, 최근 변경, 최근 커밋 메시지를 제공해 최근 변경에 초점.
- 목표: AI 피드백을 효율적이고 최근 변경에 맞춘 맥락적 리뷰로 개선.